### PR TITLE
Navigation: Remove internal state

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1044,6 +1044,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "Navigation",
+		"slug": "navigation",
+		"markdown_source": "../packages/components/src/navigation/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "Notice",
 		"slug": "notice",
 		"markdown_source": "../packages/components/src/notice/README.md",

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -1,0 +1,43 @@
+# Navigation
+
+Navigation is a component which renders a component which renders a heirarchy of menu items.
+
+## Usage
+
+```jsx
+import { MenuItem } from '@wordpress/components';
+import { withState } from '@wordpress/compose';
+
+const data = [
+    { title: 'My Navigation', slug: 'root', back: 'Back' },
+    { title: 'Home', slug: 'home', parent: 'root', menu: 'primary' },
+    { title: 'Option one', slug: 'option_one', parent: 'root', menu: 'primary' },
+    { title: 'Option two', slug: 'option_two', parent: 'root', menu: 'primary' },
+    { title: 'Option three', slug: 'option_three', parent: 'root', menu: 'secondary' },
+    { title: 'Child one', slug: 'child_one', parent: 'option_three', menu: 'primary' },
+    { title: 'Child two', slug: 'child_two', parent: 'option_three', menu: 'primary' },
+    { title: 'Child three', slug: 'child_three', parent: 'option_three', menu: 'primary' },
+];
+
+const MyNavigation = () => {
+    return <Navigation data={ data } initial="home" />;
+};
+```
+
+## Props
+
+Navigation supports the following props.
+
+### `data`
+
+- Type: `array`
+- Required: Yes
+
+An array of config objects for each menu item.
+
+### `initial`
+
+- Type: `string`
+- Required: Yes
+
+The active slug.

--- a/packages/components/src/navigation/README.md
+++ b/packages/components/src/navigation/README.md
@@ -9,18 +9,48 @@ import { MenuItem } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
 
 const data = [
-    { title: 'My Navigation', slug: 'root', back: 'Back' },
-    { title: 'Home', slug: 'home', parent: 'root', menu: 'primary' },
-    { title: 'Option one', slug: 'option_one', parent: 'root', menu: 'primary' },
-    { title: 'Option two', slug: 'option_two', parent: 'root', menu: 'primary' },
-    { title: 'Option three', slug: 'option_three', parent: 'root', menu: 'secondary' },
-    { title: 'Child one', slug: 'child_one', parent: 'option_three', menu: 'primary' },
-    { title: 'Child two', slug: 'child_two', parent: 'option_three', menu: 'primary' },
-    { title: 'Child three', slug: 'child_three', parent: 'option_three', menu: 'primary' },
+	{ title: 'My Navigation', slug: 'root', back: 'Back' },
+	{ title: 'Home', slug: 'home', parent: 'root', menu: 'primary' },
+	{
+		title: 'Option one',
+		slug: 'option_one',
+		parent: 'root',
+		menu: 'primary',
+	},
+	{
+		title: 'Option two',
+		slug: 'option_two',
+		parent: 'root',
+		menu: 'primary',
+	},
+	{
+		title: 'Option three',
+		slug: 'option_three',
+		parent: 'root',
+		menu: 'secondary',
+	},
+	{
+		title: 'Child one',
+		slug: 'child_one',
+		parent: 'option_three',
+		menu: 'primary',
+	},
+	{
+		title: 'Child two',
+		slug: 'child_two',
+		parent: 'option_three',
+		menu: 'primary',
+	},
+	{
+		title: 'Child three',
+		slug: 'child_three',
+		parent: 'option_three',
+		menu: 'primary',
+	},
 ];
 
 const MyNavigation = () => {
-    return <Navigation data={ data } initial="home" />;
+	return <Navigation data={ data } initial="home" />;
 };
 ```
 
@@ -30,14 +60,19 @@ Navigation supports the following props.
 
 ### `data`
 
-- Type: `array`
-- Required: Yes
+-   Type: `array`
+-   Required: Yes
 
 An array of config objects for each menu item.
 
-### `initial`
+### `active`
 
-- Type: `string`
-- Required: Yes
+-   Type: `string`
+-   Required: Yes
 
 The active slug.
+
+### `onSelect`
+
+-   Type: `function`
+-   Required: No

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
 import { Icon, arrowLeft } from '@wordpress/icons';
 
 /**
@@ -11,11 +10,10 @@ import Button from '../button';
 import Text from '../text';
 import Item from './item';
 
-const Navigation = ( { data, initial } ) => {
-	const initialActive = data.find( ( item ) => item.slug === initial );
-	const [ active, setActive ] = useState( initialActive );
-	const parent = data.find( ( item ) => item.slug === active.parent );
-	const items = data.filter( ( item ) => item.parent === active.parent );
+const Navigation = ( { data, active, onSelect } ) => {
+	const activeItem = data.find( ( item ) => item.slug === active );
+	const parent = data.find( ( item ) => item.slug === activeItem.parent );
+	const items = data.filter( ( item ) => item.parent === activeItem.parent );
 
 	const goBack = () => {
 		if ( ! parent.parent ) {
@@ -26,7 +24,7 @@ const Navigation = ( { data, initial } ) => {
 			( item ) => item.parent === parent.parent
 		);
 		if ( parentalSiblings.length ) {
-			setActive( parentalSiblings[ 0 ] );
+			onSelect( parentalSiblings[ 0 ].slug );
 		}
 	};
 
@@ -50,8 +48,8 @@ const Navigation = ( { data, initial } ) => {
 							key={ item.slug }
 							data={ data }
 							item={ item }
-							setActive={ setActive }
-							isActive={ item.slug === active.slug }
+							onSelect={ onSelect }
+							isActive={ item.slug === active }
 						/>
 					) : null
 				) }
@@ -63,8 +61,8 @@ const Navigation = ( { data, initial } ) => {
 							key={ item.slug }
 							data={ data }
 							item={ item }
-							setActive={ setActive }
-							isActive={ item.slug === active.slug }
+							onSelect={ onSelect }
+							isActive={ item.slug === active }
 						/>
 					) : null
 				) }

--- a/packages/components/src/navigation/index.js
+++ b/packages/components/src/navigation/index.js
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Icon, arrowLeft } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../button';
+import Text from '../text';
+import Item from './item';
+
+const Navigation = ( { data, initial } ) => {
+	const initialActive = data.find( ( item ) => item.slug === initial );
+	const [ active, setActive ] = useState( initialActive );
+	const parent = data.find( ( item ) => item.slug === active.parent );
+	const items = data.filter( ( item ) => item.parent === active.parent );
+
+	const goBack = () => {
+		if ( ! parent.parent ) {
+			// We are at top level, will need to handle this case.
+			return;
+		}
+		const parentalSiblings = data.filter(
+			( item ) => item.parent === parent.parent
+		);
+		if ( parentalSiblings.length ) {
+			setActive( parentalSiblings[ 0 ] );
+		}
+	};
+
+	return (
+		<div className="components-navigation">
+			<Button
+				isSecondary
+				className="components-navigation__back"
+				onClick={ goBack }
+			>
+				<Icon icon={ arrowLeft } />
+				{ parent.back }
+			</Button>
+			<div className="components-navigation__title">
+				<Text variant="title.medium">{ parent.title }</Text>
+			</div>
+			<div className="components-navigation__menu-items">
+				{ items.map( ( item ) =>
+					item.menu !== 'secondary' ? (
+						<Item
+							key={ item.slug }
+							data={ data }
+							item={ item }
+							setActive={ setActive }
+							isActive={ item.slug === active.slug }
+						/>
+					) : null
+				) }
+			</div>
+			<div className="components-navigation__menu-items is-secondary">
+				{ items.map( ( item ) =>
+					item.menu === 'secondary' ? (
+						<Item
+							key={ item.slug }
+							data={ data }
+							item={ item }
+							setActive={ setActive }
+							isActive={ item.slug === active.slug }
+						/>
+					) : null
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default Navigation;

--- a/packages/components/src/navigation/item.js
+++ b/packages/components/src/navigation/item.js
@@ -14,17 +14,17 @@ import { Icon, chevronRight } from '@wordpress/icons';
 import Button from '../button';
 import Text from '../text';
 
-const Item = ( { data, item, setActive, isActive } ) => {
+const Item = ( { data, item, onSelect, isActive } ) => {
 	const children = data.filter( ( d ) => d.parent === item.slug );
-	const onSelect = () => {
+	const onClick = () => {
 		const next = children.length ? children[ 0 ] : item;
-		setActive( next );
+		onSelect( next.slug );
 	};
 	const classes = classnames( 'components-navigation__menu-item', {
 		'is-active': isActive,
 	} );
 	return (
-		<Button className={ classes } onClick={ onSelect } key={ item.slug }>
+		<Button className={ classes } onClick={ onClick } key={ item.slug }>
 			<Text variant="body.small">
 				<span>{ item.title }</span>
 			</Text>

--- a/packages/components/src/navigation/item.js
+++ b/packages/components/src/navigation/item.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Icon, chevronRight } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../button';
+import Text from '../text';
+
+const Item = ( { data, item, setActive, isActive } ) => {
+	const children = data.filter( ( d ) => d.parent === item.slug );
+	const onSelect = () => {
+		const next = children.length ? children[ 0 ] : item;
+		setActive( next );
+	};
+	const classes = classnames( 'components-navigation__menu-item', {
+		'is-active': isActive,
+	} );
+	return (
+		<Button className={ classes } onClick={ onSelect } key={ item.slug }>
+			<Text variant="body.small">
+				<span>{ item.title }</span>
+			</Text>
+			{ children.length ? <Icon icon={ chevronRight } /> : null }
+		</Button>
+	);
+};
+
+export default Item;

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -1,0 +1,90 @@
+/**
+ * Internal dependencies
+ */
+import Navigation from '../';
+
+export default {
+	title: 'Components/Navigation',
+	component: Navigation,
+};
+
+const data = [
+	{ title: 'WooCommerce', slug: 'root', back: 'Dashboard' },
+	{ title: 'Home', slug: 'home', parent: 'root', menu: 'primary' },
+	{
+		title: 'Analytics',
+		slug: 'analytics',
+		parent: 'root',
+		back: 'WooCommerce Home',
+		menu: 'primary',
+	},
+	{
+		title: 'Orders',
+		slug: 'orders',
+		parent: 'root',
+		back: 'WooCommerce Home',
+		menu: 'primary',
+	},
+	{
+		title: 'Overview',
+		slug: 'overview',
+		parent: 'analytics',
+	},
+	{
+		title: 'Products report',
+		slug: 'products',
+		parent: 'analytics',
+	},
+	{
+		title: 'All orders',
+		slug: 'all_orders',
+		parent: 'orders',
+	},
+	{
+		title: 'Payouts',
+		slug: 'payouts',
+		parent: 'orders',
+	},
+	{
+		title: 'Settings',
+		slug: 'settings',
+		parent: 'root',
+		back: 'WooCommerce Home',
+		menu: 'secondary',
+	},
+	{
+		title: 'Extensions',
+		slug: 'extensions',
+		parent: 'root',
+		back: 'WooCommerce Home',
+		menu: 'secondary',
+	},
+	{
+		title: 'General',
+		slug: 'general',
+		parent: 'settings',
+	},
+	{
+		title: 'Tax',
+		slug: 'tax',
+		parent: 'settings',
+	},
+	{
+		title: 'My extensions',
+		slug: 'my_extensions',
+		parent: 'extensions',
+	},
+	{
+		title: 'Marketplace',
+		slug: 'marketplace',
+		parent: 'extensions',
+	},
+];
+
+function Example() {
+	return <Navigation data={ data } initial="home" />;
+}
+
+export const _default = () => {
+	return <Example />;
+};

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import Navigation from '../';
@@ -82,7 +88,21 @@ const data = [
 ];
 
 function Example() {
-	return <Navigation data={ data } initial="home" />;
+	const [ active, setActive ] = useState( 'home' );
+	const onSelect = ( slug ) => {
+		setActive( slug );
+	};
+	return (
+		<div style={ { display: 'flex' } }>
+			<Navigation data={ data } active={ active } onSelect={ onSelect } />
+			<div>
+				<Button onClick={ () => onSelect( 'tax' ) }>Link to Tax</Button>
+				<Button onClick={ () => onSelect( 'payouts' ) }>
+					Link to Payouts
+				</Button>
+			</div>
+		</div>
+	);
 }
 
 export const _default = () => {

--- a/packages/components/src/navigation/style.scss
+++ b/packages/components/src/navigation/style.scss
@@ -1,0 +1,30 @@
+.components-navigation {
+	width: 272px;
+	padding: 35px 30px;
+}
+
+.components-navigation__back {
+	margin-bottom: 64px;
+}
+
+.components-navigation__title {
+	margin-bottom: 40px;
+}
+
+.components-navigation__menu-items {
+	display: flex;
+	flex-direction: column;
+
+	&.is-secondary {
+		margin-top: 24px;
+	}
+}
+
+.components-navigation__menu-item {
+	display: flex;
+	justify-content: space-between;
+
+	&.is-active span {
+		border-bottom: 2px solid var(--wp-admin-theme-color);
+	}
+}

--- a/packages/components/src/style.scss
+++ b/packages/components/src/style.scss
@@ -29,6 +29,7 @@
 @import "./menu-item/style.scss";
 @import "./menu-items-choice/style.scss";
 @import "./modal/style.scss";
+@import "./navigation/style.scss";
 @import "./notice/style.scss";
 @import "./panel/style.scss";
 @import "./placeholder/style.scss";


### PR DESCRIPTION
## Description

Remove Navigation component's internal state. The component will be purely presentational and react only changes in supplied props.

## Screenshots <!-- if applicable -->

![Screen Shot 2020-07-24 at 1 05 50 PM](https://user-images.githubusercontent.com/1922453/88352612-73dba700-cdae-11ea-847f-13fab4b30657.png)

## Test instructions

1. `npm run storybook:dev`
2. Components > Navigation.
3. Ensure the component navigates as it previously has.
4. Try the new links on the right to see the component react to outside navigation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
